### PR TITLE
Fix templating

### DIFF
--- a/mendoza/init.janet
+++ b/mendoza/init.janet
@@ -90,12 +90,12 @@
   (default site "site")
   (let [port ((if (string? port) scan-number identity) port)]
     (circlet/server
-     (->
-       {:default {:kind :static
-                  :root site}}
-       circlet/router
-       circlet/logger)
-     port host)))
+      (->
+        {:default {:kind :static
+                   :root site}}
+        circlet/router
+        circlet/logger)
+      port host)))
 
 # re-export render
 (setdyn 'render (dyn 'render/render))
@@ -123,6 +123,7 @@
       :file (when (and (> (length path) 3) (= ".mdz" (string/slice path -5)))
               (print "Parsing content " path " as mendoza markup")
               (def page (require path))
+              (assert page (string "Could not parse " path ". Probably missing :template in the frontmatter?"))
               (put page :input path)
               (put page :url (page-get-url root page))
               (array/push pages page))))

--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -148,7 +148,7 @@
                               (eval ast))}))
       (def template (matter :template))
       (when (bytes? template)
-        (put matter :template (require (string template)))))
+        (put matter :template (string template))))
   (def f (fiber/new do-contents :))
   (fiber/setenv f env)
   (resume f))

--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -147,8 +147,8 @@
                {:content (seq [ast :in (tuple/slice matches 1)]
                               (eval ast))}))
       (def template (matter :template))
-      (when (bytes? template))
-        (put matter :template (require (string template))))
+      (when (bytes? template)
+        (put matter :template (require (string template)))))
   (def f (fiber/new do-contents :))
   (fiber/setenv f env)
   (resume f))

--- a/mendoza/render.janet
+++ b/mendoza/render.janet
@@ -63,7 +63,9 @@
               matches (peg/match lang content)]
           (highlight-genhtml buf matches))
         (if-let [temp (node :template)]
-          (temp buf)
+          (if (string? temp)
+            ((require temp) buf)
+            (temp buf))
           (render (node :content) buf)))
 
       # Literals

--- a/mendoza/render.janet
+++ b/mendoza/render.janet
@@ -63,9 +63,7 @@
               matches (peg/match lang content)]
           (highlight-genhtml buf matches))
         (if-let [temp (node :template)]
-          (if (string? temp)
-            ((require temp) buf)
-            (temp buf))
+          ((require temp) buf)
           (render (node :content) buf)))
 
       # Literals


### PR DESCRIPTION
I found out, that when you do not add (or misspell) `:template` key in content page frontmatter, build errored with the missing `require`, which I fixed in the `markup.janet`. But then when initialising, requiring the path returned `nil`, so I added an assert with some info, but I do not think it is the right solution. 

Can you please direct me to some more general one?

Also there is one formatting change. Should I format all the source files in this or some other PR?