### PR TITLE
Fix documentation on including templates, add mzdoc template to documentation

### DIFF
--- a/content/templating.mdz
+++ b/content/templating.mdz
@@ -52,19 +52,20 @@ your content markup will be exposed in the template as the @code`content` bindin
 Use of double curly braces in a template substitutes a node of the document graph in the final output.
 @code`node` must be a Janet expression that will be rendered and spliced into the output file. @code`node`
 will usually be either a string or a nested table, representing a DOM node that will be rendered by @code`mendoza/render`.
-You can also include other templates with the @code`template-include` fn in the node.
+You can also include other templates with the @code`{:template (require
+"template.html")}` fn in the node.
 
 @codeblock[html]```
 <!doctype html>
 <html>
   <head>
-    {{ (template-include "mytemplate/head.html") }}
+    {{ {:template (require "mytemplate/head.html")} }}
   </head>
   <body>
     {{ content }}
   </body>
   <footer>
-    {{ (template-include "mytemplate/footer.html) }}
+    {{ {:template (require "mytemplate/footer.html")} }}
   </footer>
 </html>
 ```

--- a/content/templating.mdz
+++ b/content/templating.mdz
@@ -141,4 +141,5 @@ Mendoza comes with a few built in templates. They should work well on their
 own or serve as good starting points for your own templates.
 
 @ul{@li{blueblog/main.html}
-    @li{simple/main.html}}
+    @li{simple/main.html}
+    @li{mzdoc/main.html}}

--- a/content/templating.mdz
+++ b/content/templating.mdz
@@ -53,7 +53,7 @@ Use of double curly braces in a template substitutes a node of the document grap
 @code`node` must be a Janet expression that will be rendered and spliced into the output file. @code`node`
 will usually be either a string or a nested table, representing a DOM node that will be rendered by @code`mendoza/render`.
 You can also include other templates with the @code`{:template (require
-"template.html")}` fn in the node.
+"template.html")}` in the node.
 
 @codeblock[html]```
 <!doctype html>

--- a/content/templating.mdz
+++ b/content/templating.mdz
@@ -52,19 +52,19 @@ your content markup will be exposed in the template as the @code`content` bindin
 Use of double curly braces in a template substitutes a node of the document graph in the final output.
 @code`node` must be a Janet expression that will be rendered and spliced into the output file. @code`node`
 will usually be either a string or a nested table, representing a DOM node that will be rendered by @code`mendoza/render`.
-You can also include other templates with the @code`:template` key in the node.
+You can also include other templates with the @code`template-include` fn in the node.
 
 @codeblock[html]```
 <!doctype html>
 <html>
   <head>
-    {{ {:template "mytemplate/head.html"} }}
+    {{ (template-include "mytemplate/head.html") }}
   </head>
   <body>
     {{ content }}
   </body>
   <footer>
-    {{ {:template "mytemplate/footer.html} }}
+    {{ (template-include "mytemplate/footer.html) }}
   </footer>
 </html>
 ```

--- a/content/templating.mdz
+++ b/content/templating.mdz
@@ -108,7 +108,7 @@ be included in the output html.
 <html>
   <body>
       <pre>
-        {{ (janet/encode (range 100)) }}
+        {{ (json/encode (range 100)) }}
       </pre>
   </body>
 </html>

--- a/mendoza/template.janet
+++ b/mendoza/template.janet
@@ -91,6 +91,7 @@
               (def sitemap (dyn :sitemap))
               (def url (dyn :url))
               (def content (dyn :content))
+              (defn template-include [temp] {:template (require temp)})
               ,;forms
               ,bufsym))
 

--- a/mendoza/template.janet
+++ b/mendoza/template.janet
@@ -91,7 +91,6 @@
               (def sitemap (dyn :sitemap))
               (def url (dyn :url))
               (def content (dyn :content))
-              (defn template-include [temp] {:template (require temp)})
               ,;forms
               ,bufsym))
 


### PR DESCRIPTION
~~As you suggested in the #9, I have added the `template-include` fn. I defined it as a convenience function in the `ast` as it seemed like the most straightforward solution. I changed the documentation from `:template` key to this new fn.~~

I also added the mzdoc template to the list of built-in templates.