### PR TITLE
WIP: Add id attribute to headers

### DIFF
--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -72,7 +72,10 @@
 
 (defn- caph [n & content]
   {:tag (string "h" (length n)) :content
-   (array/slice content)})
+   (array/slice content)
+   "id" (when-let [cand (first content)]
+          (when (string? cand)
+            (string/replace-all " " "" (string/trim cand))))})
 
 (def- markup-grammar
   "Grammar for markdown -> document AST parser."

--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -70,12 +70,21 @@
   (unless (empty? content)
     {:tag "p" :content (array/slice content)}))
 
+(var id-tbl @{})
+
 (defn- caph [n & content]
   {:tag (string "h" (length n)) :content
    (array/slice content)
    "id" (when-let [cand (first content)]
           (when (string? cand)
-            (string/replace-all " " "" (string/trim cand))))})
+            (let [norm-name (string/replace-all " " "-" (string/trim cand))]
+              (if-let [cnt (get id-tbl norm-name)]
+                (do
+                  (put id-tbl norm-name (inc cnt))
+                  (string norm-name "-" cnt))
+                (do
+                  (put id-tbl norm-name 0)
+                  norm-name)))))})
 
 (def- markup-grammar
   "Grammar for markdown -> document AST parser."

--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -70,7 +70,7 @@
   (unless (empty? content)
     {:tag "p" :content (array/slice content)}))
 
-(var id-tbl @{})
+(def id-tbl @{})
 
 (defn- caph [n & content]
   {:tag (string "h" (length n)) :content


### PR DESCRIPTION
This is an initial sketch of providing an id attribute to headers that originate as markdown-ish things (i.e. 1-6 `#`s).

It targets only initial string elements of the `content` parameter for `caph`: https://github.com/bakpakin/mendoza/blob/2c0010a3e84cab860651da8b961410a2f84abaf4/mendoza/markup.janet#L73

All it does is strip occurences of the space character.  Thus it's true that there is potential for collisions.

If that's a concern worth addressing, perhaps there could be a table that's populated and checked for collisions.  For a collision, possibly some string can be appended to the checked name and the result could be checked against the table (possibly leading to further checks and appending -- but this should terminate at some point).

I'm not so sure collisions would be that frequent.  Though perhaps there are some cases where people want to use the same header names within a page or that space removal could lead to collisions.  For the latter case, perhaps that makes replacing inner spaces with `-` characters a better alternative.

An alternative approach to trying to come up with non-colliding names automatically might be to halt processing and inform the user that there was a name collision -- though it seems this would also require something like a table.