### PR TITLE
Update relative link compatible with Github pages

### DIFF
--- a/content/markup-commands.mdz
+++ b/content/markup-commands.mdz
@@ -27,7 +27,7 @@ Centers some rich content in the output document.
 
 ### @code(`@codeblock[...]`)
 
-See @link[/syntax-highlighting.html]{Syntax Highlighting}
+See @link[/mendoza/syntax-highlighting.html]{Syntax Highlighting}
 
 ### @code(`@bigger{...}, @smaller{...}`)
 


### PR DESCRIPTION
The [link](https://bakpakin.github.io/mendoza/markup-commands.html) on the Github pages to syntax-highlighting is broken. Hosted pages puts everything under the `/mendoza` folder of which mdz is ignorant.

Note that this change breaks the url when locally hosting.