### PR TITLE
Add support for xml templates, to allow stuff like rss feeds  

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-# Use an approximate language for syntax highlighting (clojure is pretty close)
-*.janet linguist-language=clojure
+*.janet text eol=lf

--- a/mendoza/init.janet
+++ b/mendoza/init.janet
@@ -49,7 +49,9 @@
   [lead page]
   (def front-trim (length lead))
   (def o (page :url))
-  (or o (string (string/slice (page :input) front-trim -5) ".html")))
+  (or o (string (string/slice (page :input) front-trim -5)
+                "."
+                (page :template-ext))))
 
 (defn- rimraf
   "Remove a directory and all sub directories."

--- a/mendoza/markup.janet
+++ b/mendoza/markup.janet
@@ -139,6 +139,12 @@
   "A peg that converts markdown to html."
   (peg/compile markup-grammar))
 
+(defn- parse-template-ext [filename]
+  (let [ext (last (string/split "." filename))]
+    (match ext
+      "tmpl" "html"
+      ext)))
+
 (defn markup
   "Parse mendoza markup and evaluate it returning a document tree."
   [source]
@@ -158,6 +164,7 @@
              {:content (seq [ast :in (tuple/slice matches 1)]
                          (eval ast))}))
     (def template (matter :template))
+    (put matter :template-ext (parse-template-ext template))
     (when (bytes? template)
       (put matter :template (require (string template)))))
   (def f (fiber/new do-contents :))

--- a/mendoza/template.janet
+++ b/mendoza/template.janet
@@ -128,4 +128,7 @@
   (array/insert module/paths 2 [":sys:/mendoza/templates/:all:" :mendoza-template ".html"])
   (array/insert module/paths 3 ["./templates/:all:" :mendoza-template ".tmpl"])
   (array/insert module/paths 4 ["./mendoza/templates/:all:" :mendoza-template ".tmpl"])
-  (array/insert module/paths 5 [":sys:/mendoza/templates/:all:" :mendoza-template ".tmpl"]))
+  (array/insert module/paths 5 [":sys:/mendoza/templates/:all:" :mendoza-template ".tmpl"])
+  (array/insert module/paths 0 ["./templates/:all:" :mendoza-template ".xml"])
+  (array/insert module/paths 1 ["./mendoza/templates/:all:" :mendoza-template ".xml"])
+  (array/insert module/paths 2 [":sys:/mendoza/templates/:all:" :mendoza-template ".xml"]))


### PR DESCRIPTION
closes #26 

- updates `.gitattributes` to switch github syntax highlighting to native janet
- adds xml files to custom loader
- now uses the extension of the template file in the rendered output. `tmpl` is special cased to html, and the whole thing can still be overridden with the `url` parameter.

lets you do something like this to add an rss feed

```xml
<!-- in templates/feed.xml -->
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0">
    <channel>
        <title>{{ (dyn :title) }}</title>
        <link>{{ (dyn :host-link) }}</link>
        <description>{{ (dyn :description) }}</description>
        <language>en</language>
        <generator>Mendoza (https://github.com/bakpakin/mendoza)</generator>

        {% (loop [p :in pages :when (p :is-blog-post)] %}
        <item>
            <title>{{ (p :title) }}</title>
            <link>{{ (relative-url (p :url)) }}</link>
            <guid isPermaLink="false">{{ (relative-url (p :url)) }}</guid>
            <pubDate>{{ (p :published-date) }}</pubDate>
        </item>
        {% ) %}
    </channel>
</rss>
```

```janet
# in content/feed.mdz
{:title "An rss blog"
 :host-link "https://yoursite.com"
 :description "Random thoughts about things."
 :template "feed.xml"}
--- 
```