### PR TITLE
Use array/pop to adapt to janet#1224

### DIFF
--- a/mendoza/template-env.janet
+++ b/mendoza/template-env.janet
@@ -57,7 +57,7 @@
   be absolute from the site root, like /index.html."
   [url]
   (def b-parts (string/split "/" (dyn :url)))
-  (array/remove b-parts -2)
+  (array/pop b-parts)
   (def a-parts (string/split "/" url))
   (while (and (not= 0 (length a-parts))
               (not= 0 (length b-parts))


### PR DESCRIPTION
This PR is an attempt to adapt to a change in `array/remove`'s behavior for negative indices.

For the code this PR touches, the idea is to use `array/pop` instead.  This approach should make the resulting code continue to work with applicable versions of Janet before the `array/remove` change.

For some more details: https://github.com/janet-lang/janet/pull/1224#issuecomment-1639805709