### PR TITLE
Allow passing a watch directory to `mdz watch`

### DIFF
--- a/mdz
+++ b/mdz
@@ -11,7 +11,7 @@
 
 (def usage
   "Script usage."
-``` [action]
+  ``` [action]
 
   Actions:
     help               - Print this usage information
@@ -25,6 +25,8 @@
      [host=127.0.0.1]  -- optional host
      [site="site"]     -- output directory to serve from
     watch              - Watch files and rebuild on any change.
+     [dir=""]          -- optional directory to watch (watches "static/", 
+                       --  "templates/", "syntax/", and "content/" by default)
     version            - Print the mendoza version
 ```)
 
@@ -40,5 +42,5 @@
   "version" (print mdz/version)
   "clean" (mdz/clean (get args 2))
   "serve" (mdz/serve (get args 2) (get args 3) (get args 4))
-  "watch" (mdz/watch)
+  "watch" (mdz/watch (get args 2))
   "build" (mdz/build (get args 2) (get args 3)))

--- a/mendoza/init.janet
+++ b/mendoza/init.janet
@@ -165,11 +165,11 @@
   "Watch for files changing, and re-run mendoza when source files
   change. Only works when content files and templates change, and
   only on linux for now."
-  []
+  [& dir]
 
   # Check which directories exist
   (def watched-dirs @[])
-  (each path ["static" "templates" "syntax" "content"]
+  (each path ["static" "templates" "syntax" "content" ;dir]
     (if (os/stat path :mode)
       (array/push watched-dirs path)))
 
@@ -196,14 +196,14 @@
       (print "using inotifywait")
       (set pipe :out))
     ([_]
-     (def args ["fswatch" "-r" "-o" "-a"
-                "-e" "4913" # vim will create a test file called "4913" for terrible reasons. Like wtf.
-                "--event=Created" "--event=Updated" "--event=AttributeModified" "--event=Removed"
-                "--event=Renamed"
-                ;watched-dirs])
-     (set proc (os/spawn args :px {:out :pipe}))
-     (print "using fswatch")
-     (set pipe :out)))
+      (def args ["fswatch" "-r" "-o" "-a"
+                 "-e" "4913" # vim will create a test file called "4913" for terrible reasons. Like wtf.
+                 "--event=Created" "--event=Updated" "--event=AttributeModified" "--event=Removed"
+                 "--event=Renamed"
+                 ;watched-dirs])
+      (set proc (os/spawn args :px {:out :pipe}))
+      (print "using fswatch")
+      (set pipe :out)))
 
   (def buf @"")
   (var build-iter 0)


### PR DESCRIPTION
Currently `mdz watch` does not allow passing in a custom directory to trigger a rebuild on. This makes the `watch` subcommand much less useful in, for example, the [spork](https://github.com/janet-lang/spork) project, where `*.mdz` files are stored in `doc/`.

This extremely simple tweak allows passing a directory target to `mdz watch`, as in:

```console
~/spork $ mdz watch ./doc
```